### PR TITLE
Don't override an existing webpack config "devtool" setting

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -168,7 +168,7 @@ export default function SentryModule (moduleOptions) {
         return
       }
 
-      config.devtool = 'source-map'
+      config.devtool = config.devtool || 'source-map'
 
       // when not in spa mode upload only at server build
       if (isClient && this.options.mode !== 'spa') {


### PR DESCRIPTION
This allows using a custom devtool setting, i.e. `hidden-source-map`.